### PR TITLE
Fixed 404 error related to GET request to /profile

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,7 +81,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=4)
+            current_user = Customer.objects.get(user=request.auth.user)
             current_user.recommends = Recommendation.objects.filter(recommender=current_user)
 
             serializer = ProfileSerializer(


### PR DESCRIPTION
Description of PR that completes issue here...

Resolved issue related to the 404 error being thrown when trying to perform a GET request to '/profile'. Referencing issue ticket #41.

## Changes

- Replaced hard-coded user ID in `profile.py` for `current_user` in `def_list` with `request.auth.user`

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

**Response**

## Testing

Description of how to test code...

- [ ] Open a new GET request in Postman to `http://localhost:8000/profile`
- [ ] Be sure to have a valid user token in the Authorization header
- [ ] Send the request


## Related Issues

- Fixes #41
- Fixes #6 