### PR TITLE
(Per James) Removed extra line_items key from Profile.py viewset

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -184,7 +184,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
# Description

Removed line in Proile.py ViewSet that was causing duplicate line items

Fixes Issue Ticket #4 


## Type of change

- [ ] Bug fix

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [x] Go to Postman
- [x] Do a GET request to '/profile/cart'
- [x] Make sure there is only 1 lineitems array returned
