### PR TITLE
Updated logic of destroy method in LineItems ViewSet

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -76,7 +76,8 @@ class LineItems(ViewSet):
         """
         try:
             customer = Customer.objects.get(user=request.auth.user)
-            order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product = OrderProduct.objects.get(product__id=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
# Description
When the client sends a DELETE request to 'http://localhhost:8000/lineitems/{product_id}', the destroy method in the LineItems Viewset finds the correct order_product based on the product_id and the logged in customer and removes the order_product from the database. I changed the get() method to take 'product__id=pk', and I added a delete() method to order_product.

Fixes # (issue):
Issue Ticket #9

Related Fixes:
Issue Ticket #35 (client-side bug for same issue)

## Type of change
- [ ] Bug fix

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Log in as brenda
- [ ] Go to Cart View
- [ ] Click 'delete' trashcan icon
- [ ] Check response in network tab for 204 status code
- [ ] Check database to make sure order_product is deleted
