### PR TITLE
Defined test_delete_product() method in tests/products.py

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -308,7 +308,7 @@ class Products(ViewSet):
 
             return Response(None, status=status.HTTP_204_NO_CONTENT)
 
-        return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+        return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)    
 
     @action(methods=['post'], detail=True, url_path='rate-product')
     def rate_product(self, request, pk=None):
@@ -339,3 +339,18 @@ class Products(ViewSet):
                 {'message': f'Key {str(ex)} is required'},
                 status=status.HTTP_400_BAD_REQUEST
             )
+    @action(methods=['get'], detail=False, url_path='deleted')
+    def deleted_products(self, request):
+        """
+        @api {GET} /products/deleted GET soft-deleted products
+        @apiName GetDeletedProducts
+        @apiGroup Product
+        
+        @apiSuccess (200) {Array} products List of soft-deleted products.
+        """
+
+        # Get only soft-deleted products
+        deleted_products = Product.objects.deleted_only()
+
+        serializer = ProductSerializer(deleted_products, many=True, context={'request': request})
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/tests/product.py
+++ b/tests/product.py
@@ -103,6 +103,31 @@ class ProductTests(APITestCase):
         self.assertEqual(len(json_response), 3)
 
     # TODO: Delete product
+    def test_delete_product(self):
+        """
+        Ensure we can soft delete a product, but the product remains in the database
+        """
+        # Create 3 products
+        self.test_get_all_products()
+
+        # Delete a single product
+        url = "/products/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get all products and ensure product is not in default query
+        url = "/products"
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(len(json_response), 2)
+
+        # Ensure the deleted product is still in the database
+        url = "/products/deleted"
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(len(json_response), 1)
+        
 
     def test_add_rating_to_product(self):
         """


### PR DESCRIPTION
# Description
- Defined a test_delete_product() method in ProductTests class (tests/products.py) for a soft delete of product 
- Added deleted_products @action decorator in Products ViewSet that returns all products that have a deleted property that is not NULL when a request to '/products/deleted' is sent

Fixes # (issue)
#22 

## Type of change

Please delete options that are not relevant.

- [ ] Test

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no errors

# How Should I Test This?

- [ ] Step 1 Fetch or pull the changes from this repo
- [ ] Step 2 In your command line interface, navigate to the project directory (bangazon-api-jteam)
- [ ] Step 3 Run the following command and confirm that all tests run successfully python3 manage.py test tests -v 1