### PR TITLE
Fixed incorrect related_name reference to Favorites model in ProfileS…

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -146,7 +146,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     received_recommendations = ReceivedRecommendationSerializer(
         many=True
     )  # Recommendations made to the user
-    favorites = FavoriteSerializer(many=True, source="favorite_set")
+    favorites = FavoriteSerializer(many=True, source="favorite_stores")
     likes = LikeSerializer(many=True, source="like_set")
 
     class Meta:


### PR DESCRIPTION
…erializer

# Description
'500 internal server' error popped up when trying to access a User's Profile after the related_name property was changed in the Favorite Model. I updated the reference to the related_name property in the Profile ViewSet so it correctly references the changed related_name property.

Fixes # (issue)
(No issue ticket)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no errors

# How Should I Test This?

- [ ] Fetch the API branch
- [ ] Log in as Brenda
- [ ] Go to Profile view and make sure no internal server error pops up in the client browser
- [ ] Logged in as Brenda, there should be data displaying for all Profile sections, including favorite stores