### PR TITLE
Feature: Store View

### DIFF
--- a/bangazonapi/fixtures/favoritesellers.json
+++ b/bangazonapi/fixtures/favoritesellers.json
@@ -1,26 +1,26 @@
 [
-    {
-        "pk": 1,
-        "model": "bangazonapi.favorite",
-        "fields": {
-            "customer_id": 7,
-            "store_id": 1
-        }
-    },
-    {
-        "pk": 2,
-        "model": "bangazonapi.favorite",
-        "fields": {
-            "customer_id": 7,
-            "store_id": 2
-        }
-    },
-    {
-        "pk": 3,
-        "model": "bangazonapi.favorite",
-        "fields": {
-            "customer_id": 7,
-            "store_id": 1
-        }
+  {
+    "pk": 1,
+    "model": "bangazonapi.favorite",
+    "fields": {
+      "customer_id": 7,
+      "store_id": 1
     }
+  },
+  {
+    "pk": 2,
+    "model": "bangazonapi.favorite",
+    "fields": {
+      "customer_id": 7,
+      "store_id": 2
+    }
+  },
+  {
+    "pk": 3,
+    "model": "bangazonapi.favorite",
+    "fields": {
+      "customer_id": 7,
+      "store_id": 3
+    }
+  }
 ]

--- a/bangazonapi/fixtures/stores.json
+++ b/bangazonapi/fixtures/stores.json
@@ -16,5 +16,14 @@
       "name": "Joe's Store",
       "description": "Joe's Joyful Junk"
     }
+  },
+  {
+    "model": "bangazonapi.Store",
+    "pk": 3,
+    "fields": {
+      "customer_id": 7,
+      "name": "J Crew",
+      "description": "Clothing for people with J's in their name"
+    }
   }
 ]

--- a/bangazonapi/models/favorite.py
+++ b/bangazonapi/models/favorite.py
@@ -4,12 +4,14 @@ from django.db import models
 class Favorite(models.Model):
 
     customer = models.ForeignKey(
-        "Customer",
-        on_delete=models.DO_NOTHING,
-        related_name="favorite_stores"
+        "Customer", on_delete=models.DO_NOTHING, related_name="favorite_stores"
     )
     store = models.ForeignKey(
-        "Store", 
-        on_delete=models.DO_NOTHING, 
-        related_name="favorited_by_customers"
+        "Store",
+        on_delete=models.DO_NOTHING,
+        related_name="favorited_by_customers",
+        null=True,
     )
+
+    class Meta:
+        unique_together = ("customer", "store")  # Prevents duplicate favorites

--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -1,10 +1,10 @@
 from django.db import models
 
+
 class Store(models.Model):
 
-    customer = models.ForeignKey(
-        "Customer",
-        on_delete=models.DO_NOTHING, 
+    customer = models.OneToOneField(
+        "Customer", on_delete=models.DO_NOTHING, related_name="store"
     )
     name = models.CharField(
         max_length=255,

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -148,6 +148,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     )  # Recommendations made to the user
     favorites = FavoriteSerializer(many=True, source="favorite_stores")
     likes = LikeSerializer(many=True, source="like_set")
+    store = StoreSerializer(many=False, read_only=True)
 
     class Meta:
         model = Customer
@@ -162,6 +163,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "received_recommendations",
             "favorites",
             "likes",
+            "store",
         )
         depth = 1
 

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -1,28 +1,37 @@
 from rest_framework import serializers, viewsets
 from django.contrib.auth.models import User
-from bangazonapi.models import Store, Customer
+from bangazonapi.models import Store, Customer, StoreProduct
 from rest_framework.response import Response
 from rest_framework.decorators import action
+from .product import ProductSerializer
 
 
 class StoreOwnerSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ("id", "first_name", "last_name",)
+        fields = (
+            "id",
+            "first_name",
+            "last_name",
+        )
+
 
 class StoreSerializer(serializers.ModelSerializer):
     """JSON serializer"""
 
     customer = StoreOwnerSerializer(source="customer.user", read_only=True)
+    products = serializers.SerializerMethodField()
+
+    def get_products(self, obj):
+        # Get all StoreProduct objects for this store
+        store_products = StoreProduct.objects.filter(store=obj)
+        # Extract the actual Product objects
+        products = [sp.product for sp in store_products]
+        return ProductSerializer(products, many=True, context={'request': self.context.get('request')}).data
 
     class Meta:
         model = Store
-        fields = (
-            "id",
-            "customer",
-            "name",
-            "description",
-        )
+        fields = ("id", "customer", "name", "description", "products")
         read_only_fields = ["customer"]
 
 
@@ -31,21 +40,26 @@ class StoreViewSet(viewsets.ModelViewSet):
     serializer_class = StoreSerializer
     pagination_class = None
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['request'] = self.request
+        return context
+
     def perform_create(self, serializer):
         # Fetch the logged-in user's related customer instance
         customer = Customer.objects.get(user=self.request.user)
         serializer.save(customer=customer)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def favorite(self, request, pk=None):
         store = self.get_object()
         customer = Customer.objects.get(user=request.user)
         customer.add_favorite_store(store)
-        return Response({'status': 'store favorited'})
+        return Response({"status": "store favorited"})
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def unfavorite(self, request, pk=None):
         store = self.get_object()
         customer = Customer.objects.get(user=request.user)
         customer.remove_favorite_store(store)
-        return Response({'status': 'store unfavorited'})
+        return Response({"status": "store unfavorited"})


### PR DESCRIPTION
# Description
A user can now view their store, if they've created one. The products that store sells, as well as the products that have been sold, will display when viewing a store. 

To update the API to handle this new feature a few changes were made:
1. Updates to the fixtures and `favorite`, and `store` models were made so a `store` field could be added to the `profile` serializer.
2. Added a `get_products` decorator to the `store.py` viewset so that the `products` field could be added to the `StoreSerializer`
3. Added a `get_products_sold` decorator to the `store.py` viewset so that the `products_sold` field could be added to the `StoreSerializer`


Fixes #24, #25 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Step 1 Fetch the changes from this repo
- [ ] Step 2 Restart your API
- [ ] Step 3 In Postman, GET all stores `http://localhost:8000/stores` and confirm that the `products` and `products_sold` fields are in the response
- [ ] Step 4 *OPTIONAL* In Postman, GET a user profile of a user who has a store `http://localhost:8000/profile` and confirm that the `store` field is in the response
