### PR TITLE
Feature/favorite store

### DIFF
--- a/bangazonapi/models/customer.py
+++ b/bangazonapi/models/customer.py
@@ -9,6 +9,11 @@ class Customer(models.Model):
     user = models.OneToOneField(User, on_delete=models.DO_NOTHING,)
     phone_number = models.CharField(max_length=15)
     address = models.CharField(max_length=55)
+    favorited_stores = models.ManyToManyField(
+        "Store",
+        through="Favorite",
+        related_name="fav_stores"
+    )
 
     @property
     def recommends(self):
@@ -18,8 +23,8 @@ class Customer(models.Model):
     def recommends(self, value):
         self.__recommends = value
 
-    def add_favorite_store(self, store):
-        Favorite.objects.get_or_create(customer=self, store=store)
+    # def add_favorite_store(self, store):
+    #     Favorite.objects.get_or_create(customer=self, store=store)
 
-    def remove_favorite_store(self, store):
-        Favorite.objects.filter(customer=self, store=store).delete()
+    # def remove_favorite_store(self, store):
+    #     Favorite.objects.filter(customer=self, store=store).delete()

--- a/bangazonapi/models/customer.py
+++ b/bangazonapi/models/customer.py
@@ -22,9 +22,3 @@ class Customer(models.Model):
     @recommends.setter
     def recommends(self, value):
         self.__recommends = value
-
-    # def add_favorite_store(self, store):
-    #     Favorite.objects.get_or_create(customer=self, store=store)
-
-    # def remove_favorite_store(self, store):
-    #     Favorite.objects.filter(customer=self, store=store).delete()

--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.conf import settings
 
 
 class Store(models.Model):
@@ -12,6 +13,19 @@ class Store(models.Model):
     description = models.CharField(
         max_length=255,
     )
+
+
+    @property
+    def is_favorite(self):
+        """
+        Favorited property for store
+        Returns boolean for if the store is favorited by the logged in user or not
+        """
+        return self.__is_favorite
+    
+    @is_favorite.setter
+    def is_favorite(self, value):
+        self.__is_favorite = value
 
     class Meta:
         verbose_name = "store"

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -117,7 +117,7 @@ class FavoriteSellerSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class FavoriteSerializer(serializers.ModelSerializer):
-    """JSON serializer for favorites"""
+    """JSON serializer for customer's favorite stores"""
 
     store = StoreSerializer(read_only=True)
 
@@ -148,7 +148,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     received_recommendations = ReceivedRecommendationSerializer(
         many=True
     )  # Recommendations made to the user
-    favorites = FavoriteSerializer(many=True, source="favorited_stores")
+    favorites = FavoriteSerializer(many=True)
     likes = LikeSerializer(many=True, source="like_set")
     store = StoreSerializer(many=False, read_only=True)
 
@@ -247,6 +247,13 @@ class Profile(ViewSet):
             current_user.received_recommendations = Recommendation.objects.filter(
                 customer=current_user
             )
+
+            current_user.favorites = Favorite.objects.filter(customer=current_user)
+
+            try:
+                current_user.store = Store.objects.get(customer=current_user)
+            except Store.DoesNotExist:
+                current_user.store = None
 
             serializer = ProfileSerializer(
                 current_user, many=False, context={"request": request}

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -79,19 +79,19 @@ class StoreViewSet(viewsets.ModelViewSet):
         customer = Customer.objects.get(user=self.request.user)
         serializer.save(customer=customer)
 
-    @action(detail=True, methods=["post"])
-    def favorite(self, request, pk=None):
-        store = self.get_object()
-        customer = Customer.objects.get(user=request.user)
-        customer.add_favorite_store(store)
-        return Response({"status": "store favorited"})
+    # @action(detail=True, methods=["post"])
+    # def favorite(self, request, pk=None):
+    #     store = self.get_object()
+    #     customer = Customer.objects.get(user=request.user)
+    #     customer.add_favorite_store(store)
+    #     return Response({"status": "store favorited"})
 
-    @action(detail=True, methods=["post"])
-    def unfavorite(self, request, pk=None):
-        store = self.get_object()
-        customer = Customer.objects.get(user=request.user)
-        customer.remove_favorite_store(store)
-        return Response({"status": "store unfavorited"})
+    # @action(detail=True, methods=["post"])
+    # def unfavorite(self, request, pk=None):
+    #     store = self.get_object()
+    #     customer = Customer.objects.get(user=request.user)
+    #     customer.remove_favorite_store(store)
+    #     return Response({"status": "store unfavorited"})
 
     
     def retrieve(self, request, pk=None):

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -1,8 +1,9 @@
 from rest_framework import serializers, viewsets
 from django.contrib.auth.models import User
-from bangazonapi.models import Store, Customer, StoreProduct, Order, OrderProduct
+from bangazonapi.models import Store, Customer, Favorite, StoreProduct, OrderProduct
 from rest_framework.response import Response
 from rest_framework.decorators import action
+from django.http import HttpResponseServerError
 from .product import ProductSerializer
 
 
@@ -19,6 +20,7 @@ class StoreSerializer(serializers.ModelSerializer):
     """JSON serializer"""
 
     customer = StoreOwnerSerializer(source="customer.user", read_only=True)
+    is_favorite = serializers.SerializerMethodField()
     products = serializers.SerializerMethodField()
     products_sold = serializers.SerializerMethodField()
 
@@ -51,8 +53,15 @@ class StoreSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Store
-        fields = ("id", "customer", "name", "description", "products", "products_sold")
+        fields = ("id", "customer", "name", "description", "products", "products_sold", "is_favorite")
         read_only_fields = ["customer"]
+    
+    def get_is_favorite(self, obj):
+        """Check if the current user has favorited the store"""
+        user = self.context['request'].user
+
+        customer = Customer.objects.get(user=user)
+        return Favorite.objects.filter(customer=customer, store=obj).exists()
 
 
 class StoreViewSet(viewsets.ModelViewSet):
@@ -83,3 +92,27 @@ class StoreViewSet(viewsets.ModelViewSet):
         customer = Customer.objects.get(user=request.user)
         customer.remove_favorite_store(store)
         return Response({"status": "store unfavorited"})
+
+    
+    def retrieve(self, request, pk=None):
+        """
+        GET request for a single store
+        """
+        try:
+            store = Store.objects.get(pk=pk)
+            serializer = StoreSerializer(store, context={"request": request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+    
+    def list(self, request):
+        """
+        GET request for a single store
+        """
+        try:
+            stores = Store.objects.all()
+            serializer = StoreSerializer(stores, context={"request": request}, many=True)
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+


### PR DESCRIPTION
When a logged in Customer favorites or unfavorites a store, a relationship is created or deleted in the database, and a favorites array containing an array of all the stores a customer has favorited are sent in the profile response to the client.

## Changes
- Added "post" and "delete" methods to the favoritesellers() decorator and logic to check the kind of sent request to '/profile/favoritesellers' endpoint
- Added custom serializer method to StoreSerializer to get a logged in customer's stores they have favorited && an "is_favorite" property
- Added retrieve() and list() methods to StoreViewSet
```

## Testing
- In the client browser log in as an admin user
- Favorite a store that does not belong to the logged in user
- Make sure a favorite relationship is created in the database
- Then unfavorite that store and make sure the favorite is deleted from the database
- Check the network tab to see if favorites array is sent in the Profile fetch